### PR TITLE
Support for prefix and suffix in templateLoader

### DIFF
--- a/src/main/java/org/springframework/web/servlet/view/mustache/MustacheTemplateLoader.java
+++ b/src/main/java/org/springframework/web/servlet/view/mustache/MustacheTemplateLoader.java
@@ -32,8 +32,25 @@ import com.samskivert.mustache.Mustache.TemplateLoader;
 public class MustacheTemplateLoader implements TemplateLoader, ResourceLoaderAware {
 
     private ResourceLoader resourceLoader;
+    private String prefix = "";
+    private String suffix = "";
 
+    public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public void setSuffix(String suffix) {
+		this.suffix = suffix;
+	}
+
+	@Override
     public Reader getTemplate(String filename) throws Exception {
+    	if (!filename.startsWith(prefix)) {
+    		filename = prefix + filename;
+    	}
+    	if (!filename.endsWith(suffix)) {
+    		filename = filename + suffix;
+    	}
         Resource resource = resourceLoader.getResource(filename);
         if (resource.exists()) {
             return new InputStreamReader(resource.getInputStream());

--- a/src/main/java/org/springframework/web/servlet/view/mustache/MustacheViewResolver.java
+++ b/src/main/java/org/springframework/web/servlet/view/mustache/MustacheViewResolver.java
@@ -60,6 +60,8 @@ public class MustacheViewResolver extends AbstractTemplateViewResolver implement
 
     @Override
     public void afterPropertiesSet() throws Exception {
+    	templateLoader.setPrefix(getPrefix());
+    	templateLoader.setSuffix(getSuffix());
         compiler = Mustache.compiler()
                 .escapeHTML(escapeHTML)
                 .standardsMode(standardsMode)


### PR DESCRIPTION
Pass prefix and suffix to templateLoader, so you can use partials by simply referring to 'footer' instead of full '/WEB-INF/views/footer.html'
