### PR TITLE
 Prevented MustacheView from writing to the response in case template fails to render

### DIFF
--- a/src/main/java/org/springframework/web/servlet/view/mustache/MustacheView.java
+++ b/src/main/java/org/springframework/web/servlet/view/mustache/MustacheView.java
@@ -39,11 +39,8 @@ public class MustacheView extends AbstractTemplateView {
 
         response.setContentType(getContentType());
         final Writer writer = response.getWriter();
-        try {
-            template.execute(model, writer);
-        } finally {
-            writer.flush();
-        }
+        template.execute(model, writer);
+        writer.flush();
     }
 
     public void setTemplate(Template template) {


### PR DESCRIPTION
Removed try finally block to let the servlet render an error response.
