### PR TITLE
Add support to return default message if no one was found

### DIFF
--- a/src/main/java/org/springframework/web/servlet/i18n/MustacheLocalizationMessageInterceptor.java
+++ b/src/main/java/org/springframework/web/servlet/i18n/MustacheLocalizationMessageInterceptor.java
@@ -54,14 +54,22 @@ public abstract class MustacheLocalizationMessageInterceptor extends HandlerInte
 
     private MessageSource messageSource;
     private LocaleResolver localeResolver;
-
+    private boolean useDefaultMessage;
+    private String defaultMessage;
 
     protected final void localize(final HttpServletRequest request, String frag, Writer out) throws IOException {
         final Locale locale = localeResolver.resolveLocale(request);
         final String key = extractKey(frag);
         final List<String> args = extractParameters(frag);
-        final String text = messageSource.getMessage(key, args.toArray(), locale);
+        final String text = this.getMessage(key, args, locale);
         out.write(text);
+    }
+
+    private String getMessage(String key, List<String> args, Locale locale) {
+        if (useDefaultMessage) {
+            return this.messageSource.getMessage(key, args.toArray(), this.defaultMessage, locale);
+        }
+        return this.messageSource.getMessage(key, args.toArray(), locale);
     }
 
     protected abstract Object createHelper(final HttpServletRequest request);
@@ -133,5 +141,11 @@ public abstract class MustacheLocalizationMessageInterceptor extends HandlerInte
         this.localeResolver = localeResolver;
     }
 
+    public void setDefaultMessage(String defaultMessage) {
+        this.defaultMessage = defaultMessage;
+    }
 
+    public void setUseDefaultMessage(boolean useDefaultMessage) {
+        this.useDefaultMessage = useDefaultMessage;
+    }
 }

--- a/src/test/java/org/springframework/web/servlet/view/mustache/java/LocalizationMessageInterceptorTest.java
+++ b/src/test/java/org/springframework/web/servlet/view/mustache/java/LocalizationMessageInterceptorTest.java
@@ -4,17 +4,25 @@
 package org.springframework.web.servlet.view.mustache.java;
 
 import com.google.common.base.Function;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.MessageSource;
+import org.springframework.context.NoSuchMessageException;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Locale;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
@@ -23,7 +31,7 @@ import static org.mockito.Mockito.*;
  * @author Sean Scanlon <sean.scanlon@gmail.com>
  */
 public class LocalizationMessageInterceptorTest {
-
+    private static final String DEFAULT_MESSAGE = "DEFAULT_MESSAGE";
     private MessageSource messageSource;
     private LocaleResolver localeResolver;
 
@@ -77,5 +85,52 @@ public class LocalizationMessageInterceptorTest {
 
         verifyNoMoreInteractions(messageSource);
 
+    }
+
+    @Test
+    public void whenExecute_givenDefaultMessageAndLabelDoesntExist_thenOutputDefaultMessage() throws Exception {
+        interceptor.setUseDefaultMessage(true);
+        interceptor.setDefaultMessage(DEFAULT_MESSAGE);
+
+        ModelAndView modelAndView = mock(ModelAndView.class);
+        ArgumentCaptor<Mustache.Lambda> captor = ArgumentCaptor.forClass(Mustache.Lambda.class);
+
+        interceptor.postHandle(request, response, handler, modelAndView);
+
+        verify(modelAndView).addObject(eq(messageKey), captor.capture());
+
+        // exercise the in-lined Lambda
+        Function<String, String> function = (Function<String, String>) captor.getValue();
+        assertNotNull(function);
+
+        String fragResult = "bar";
+
+        when(localeResolver.resolveLocale(request)).thenReturn(Locale.CANADA_FRENCH);
+        when(messageSource.getMessage(fragResult, new Object[]{}, DEFAULT_MESSAGE, Locale.CANADA_FRENCH)).thenReturn(DEFAULT_MESSAGE);
+
+        String out = function.apply(fragResult);
+
+        assertEquals(DEFAULT_MESSAGE, out);
+    }
+
+    @Test(expected = NoSuchMessageException.class)
+    public void whenExecute_givenDefaultMessageNullAndLabelDoesntExist_thenThrowException() throws Exception {
+        ModelAndView modelAndView = mock(ModelAndView.class);
+        ArgumentCaptor<Mustache.Lambda> captor = ArgumentCaptor.forClass(Mustache.Lambda.class);
+
+        interceptor.postHandle(request, response, handler, modelAndView);
+
+        verify(modelAndView).addObject(eq(messageKey), captor.capture());
+
+        // exercise the in-lined Lambda
+        Function<String, String> function = (Function<String, String>) captor.getValue();
+        assertNotNull(function);
+
+        String fragResult = "bar";
+
+        when(localeResolver.resolveLocale(request)).thenReturn(Locale.CANADA_FRENCH);
+        when(messageSource.getMessage(fragResult, new Object[]{}, Locale.CANADA_FRENCH)).thenThrow(NoSuchMessageException.class);
+
+        function.apply(fragResult);
     }
 }


### PR DESCRIPTION
Add support to not throw NoSuchMessageException when a label doesn't exist. 

Possible use case

1. Set useDefaultMessage to false (default value). Will throw NoSuchMessageException when label is not found
2. Set useDefaultMessage to true and specify a default message for all the application
3. Set useDefaultMessage to true and default message to null. MessageSource fallback is gonna be used in that case. Possible fallback is 

``
messageSource.setUseCodeAsDefaultMessage(true);
``